### PR TITLE
Link CircleCI and cybernode

### DIFF
--- a/devops/README.md
+++ b/devops/README.md
@@ -8,3 +8,13 @@ docker-compose up -d
 ```
 
 Than, all local kafka data will be stored in *devops/out/* folder.
+
+# Image deployment
+
+Image deployment process is handled by Circle CI:
+https://github.com/cyberFund/cyber-markets/blob/development/.circleci/config.yml
+
+# e2e image testing
+
+End-to-end image builds and testing are maintained in:
+https://github.com/cyberFund/cybernode/tree/master/images


### PR DESCRIPTION
Need to be aware of different places where image build scripts are placed. Cybernode checkout is important when CircleCI or DockerHub goes down or we need to work with custom cluster in offline environment (such as the basement of some Kaliningrad bars). :)