### PR TITLE
cyber-markets-47-trade

### DIFF
--- a/stream-api/src/main/kotlin/fund/cyber/markets/api/common/IncomingMessageGetTopicType.kt
+++ b/stream-api/src/main/kotlin/fund/cyber/markets/api/common/IncomingMessageGetTopicType.kt
@@ -1,0 +1,8 @@
+package fund.cyber.markets.api.common
+
+/**
+ * @author mgergalov
+ */
+enum class IncomingMessageGetTopicType {
+    PAIRS, EXCHANGES
+}

--- a/stream-api/src/main/kotlin/fund/cyber/markets/api/common/IncomingMessagesHandler.kt
+++ b/stream-api/src/main/kotlin/fund/cyber/markets/api/common/IncomingMessagesHandler.kt
@@ -1,14 +1,18 @@
 package fund.cyber.markets.api.common
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import fund.cyber.markets.api.configuration.AppContext
 import fund.cyber.markets.api.trades.TokensPairTradesBroadcaster
 import fund.cyber.markets.api.trades.TradesBroadcastersIndex
 import io.undertow.websockets.core.AbstractReceiveListener
 import io.undertow.websockets.core.BufferedTextMessage
 import io.undertow.websockets.core.StreamSourceFrameChannel
 import io.undertow.websockets.core.WebSocketChannel
+import io.undertow.websockets.core.WebSockets
 
 class IncomingMessagesHandler(
-        private val tradesBroadcastersIndex: TradesBroadcastersIndex
+        private val tradesBroadcastersIndex: TradesBroadcastersIndex,
+        private val jsonSerializer: ObjectMapper = AppContext.jsonSerializer
 ) : AbstractReceiveListener() {
 
     private val commandsParser = WebSocketCommandsParser()
@@ -18,8 +22,22 @@ class IncomingMessagesHandler(
         val command = commandsParser.parseMessage(bufferedMessage.data)
         when (command) {
             is UnknownCommand -> {}
+            is TradeChannelInfoCommand -> {
+                when (command.type) {
+                    IncomingMessageGetTopicType.PAIRS ->
+                        WebSockets.sendText(
+                                jsonSerializer.writeValueAsString(
+                                        tradesBroadcastersIndex.broadcastersGetAllPairs()),
+                                wsChannel,null)
+                    IncomingMessageGetTopicType.EXCHANGES ->
+                        WebSockets.sendText(
+                                jsonSerializer.writeValueAsString(
+                                        tradesBroadcastersIndex.broadcastersGetExchangesTree()),
+                                wsChannel, null)
+                }
+            }
             is TradeChannelSubscriptionCommand -> {
-                filterBroadcast(command)?.forEach { broadcaster ->
+                filterSubscriptionBroadcast(command)?.forEach { broadcaster ->
                     broadcaster.registerChannel(wsChannel)
                 }
             }
@@ -30,7 +48,7 @@ class IncomingMessagesHandler(
         super.onClose(webSocketChannel, channel)
     }
 
-    private fun filterBroadcast(command: TradeChannelSubscriptionCommand) : Collection<TokensPairTradesBroadcaster> {
+    private fun filterSubscriptionBroadcast(command: TradeChannelSubscriptionCommand) : Collection<TokensPairTradesBroadcaster> {
         return when {
             command.pairs!=null && command.exchanges!=null -> tradesBroadcastersIndex.broadcastersFor(command.pairs, command.exchanges)
             command.pairs!= null -> tradesBroadcastersIndex.broadcastersForPairs(command.pairs)

--- a/stream-api/src/main/kotlin/fund/cyber/markets/api/common/WebSocketCommandsParser.kt
+++ b/stream-api/src/main/kotlin/fund/cyber/markets/api/common/WebSocketCommandsParser.kt
@@ -10,11 +10,12 @@ sealed class WebSocketCommand
 class UnknownCommand(val message: String) : WebSocketCommand()
 
 // {"subscribe":"trades","pairs":["BTC_ETH","ETH_USD"]}
-class TradeChannelSubscriptionCommand(val pairs: List<TokensPair>?,
-                                      val exchanges: List<String>?) : WebSocketCommand()
+class TradeChannelSubscriptionCommand(
+        val pairs: List<TokensPair>?,
+        val exchanges: List<String>?
+) : WebSocketCommand()
 
 class TradeChannelInfoCommand(val type: IncomingMessageGetTopicType) : WebSocketCommand()
-
 
 class WebSocketCommandsParser(
         private val jsonDeserializer: ObjectMapper = AppContext.jsonDeserializer
@@ -32,7 +33,7 @@ class WebSocketCommandsParser(
     private fun parseMessage(message: String, jsonMessage: JsonNode): WebSocketCommand {
         val subscribeTopic = jsonMessage["subscribe"]?.asText()
         val getTopic = jsonMessage["get"]?.asText()
-        if (getTopic!=null) {
+        if (getTopic != null) {
             return when (getTopic.toUpperCase()) {
                 IncomingMessageGetTopicType.PAIRS.name ->
                     TradeChannelInfoCommand(IncomingMessageGetTopicType.PAIRS)
@@ -48,12 +49,12 @@ class WebSocketCommandsParser(
     }
 
     private fun parseTradesSubscription(jsonMessage: JsonNode): WebSocketCommand {
-        var pairs = jsonMessage["pairs"]?.toList()
-                ?.map { pairLabel -> TokensPair.fromLabel(pairLabel.asText(), "_") }
-                ?.toList()
-        var exchanges = jsonMessage["exchanges"]?.toList()
-                ?.map { exchange -> exchange.asText() }
-                ?.toList()
+        val pairs = jsonMessage["pairs"].toList()
+                .map { pairLabel -> TokensPair.fromLabel(pairLabel.asText(), "_") }
+                .toList()
+        val exchanges = jsonMessage["exchanges"].toList()
+                .map { exchange -> exchange.asText() }
+                .toList()
         return TradeChannelSubscriptionCommand(pairs, exchanges);
     }
 }

--- a/stream-api/src/main/kotlin/fund/cyber/markets/api/common/WebSocketCommandsParser.kt
+++ b/stream-api/src/main/kotlin/fund/cyber/markets/api/common/WebSocketCommandsParser.kt
@@ -10,7 +10,8 @@ sealed class WebSocketCommand
 class UnknownCommand(val message: String) : WebSocketCommand()
 
 // {"subscribe":"trades","pairs":["BTC_ETH","ETH_USD"]}
-class TradeChannelSubscriptionCommand(val pairs: List<TokensPair>) : WebSocketCommand()
+class TradeChannelSubscriptionCommand(val pairs: List<TokensPair>?,
+                                      val exchanges: List<String>?) : WebSocketCommand()
 
 
 class WebSocketCommandsParser(
@@ -35,9 +36,12 @@ class WebSocketCommandsParser(
     }
 
     private fun parseTradesSubscription(jsonMessage: JsonNode): WebSocketCommand {
-        val pairs = jsonMessage["pairs"].toList()
-                .map { pairLabel -> TokensPair.fromLabel(pairLabel.asText(), "_") }
-                .toList()
-        return TradeChannelSubscriptionCommand(pairs)
+        var pairs = jsonMessage["pairs"]?.toList()
+                ?.map { pairLabel -> TokensPair.fromLabel(pairLabel.asText(), "_") }
+                ?.toList()
+        var exchanges = jsonMessage["exchanges"]?.toList()
+                ?.map { exchange -> exchange.asText() }
+                ?.toList()
+        return TradeChannelSubscriptionCommand(pairs, exchanges);
     }
 }

--- a/stream-api/src/main/kotlin/fund/cyber/markets/api/common/WebSocketCommandsParser.kt
+++ b/stream-api/src/main/kotlin/fund/cyber/markets/api/common/WebSocketCommandsParser.kt
@@ -2,6 +2,7 @@ package fund.cyber.markets.api.common
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import fund.cyber.markets.api.common.IncomingMessageGetTopicType.*
 import fund.cyber.markets.api.configuration.AppContext
 import fund.cyber.markets.model.TokensPair
 
@@ -11,8 +12,8 @@ class UnknownCommand(val message: String) : WebSocketCommand()
 
 // {"subscribe":"trades","pairs":["BTC_ETH","ETH_USD"]}
 class TradeChannelSubscriptionCommand(
-        val pairs: List<TokensPair>?,
-        val exchanges: List<String>?
+        val pairs: List<TokensPair>,
+        val exchanges: List<String>
 ) : WebSocketCommand()
 
 class TradeChannelInfoCommand(val type: IncomingMessageGetTopicType) : WebSocketCommand()
@@ -35,10 +36,8 @@ class WebSocketCommandsParser(
         val getTopic = jsonMessage["get"]?.asText()
         if (getTopic != null) {
             return when (getTopic.toUpperCase()) {
-                IncomingMessageGetTopicType.PAIRS.name ->
-                    TradeChannelInfoCommand(IncomingMessageGetTopicType.PAIRS)
-                IncomingMessageGetTopicType.EXCHANGES.name ->
-                    TradeChannelInfoCommand(IncomingMessageGetTopicType.EXCHANGES)
+                PAIRS.name -> TradeChannelInfoCommand(PAIRS)
+                EXCHANGES.name -> TradeChannelInfoCommand(EXCHANGES)
                 else -> UnknownCommand(message)
             }
         }
@@ -49,12 +48,12 @@ class WebSocketCommandsParser(
     }
 
     private fun parseTradesSubscription(jsonMessage: JsonNode): WebSocketCommand {
-        val pairs = jsonMessage["pairs"].toList()
-                .map { pairLabel -> TokensPair.fromLabel(pairLabel.asText(), "_") }
-                .toList()
-        val exchanges = jsonMessage["exchanges"].toList()
-                .map { exchange -> exchange.asText() }
-                .toList()
-        return TradeChannelSubscriptionCommand(pairs, exchanges);
+        val pairs = jsonMessage["pairs"]?.toList()
+                ?.map { pairLabel -> TokensPair.fromLabel(pairLabel.asText(), "_") }
+                ?.toList() ?: emptyList()
+        val exchanges = jsonMessage["exchanges"]?.toList()
+                ?.map { exchange -> exchange.asText() }
+                ?.toList() ?: emptyList()
+        return TradeChannelSubscriptionCommand(pairs, exchanges)
     }
 }

--- a/stream-api/src/main/kotlin/fund/cyber/markets/api/trades/TradesBroadcastersIndex.kt
+++ b/stream-api/src/main/kotlin/fund/cyber/markets/api/trades/TradesBroadcastersIndex.kt
@@ -13,38 +13,31 @@ class TradesBroadcastersIndex : TradesChannelsIndexUpdateListener {
         index.getOrPut(pair, { HashMap() }).put(exchange, broadcaster)
     }
 
-    fun broadcastersForPairs (pairs: List<TokensPair>): Collection<TokensPairTradesBroadcaster> {
-        return index
-                .filter { (pair, _) -> pairs.contains(pair) }
-                .flatMap { (_, pairIndex) -> pairIndex.values }
-    }
-
     fun broadcastersFor(pairs: List<TokensPair>, exchanges: List<String> ): Collection<TokensPairTradesBroadcaster> {
-        return index
-                .filter { (pair, _) -> pairs.contains(pair) }
-                .flatMap { (_, pairIndex) -> pairIndex.entries }
-                .filter { (exchange, _) -> exchanges.contains(exchange)}
-                .map { (_, broadcaster) -> broadcaster }
+        return when {
+            !pairs.isEmpty() && !exchanges.isEmpty() -> index
+                    .filter { (pair, _) -> pairs.contains(pair) }
+                    .flatMap { (_, pairIndex) -> pairIndex.entries }
+                    .filter { (exchange, _) -> exchanges.contains(exchange) }
+                    .map { (_, broadcaster) -> broadcaster }
+            !pairs.isEmpty() -> index
+                    .filter { (pair, _) -> pairs.contains(pair) }
+                    .flatMap { (_, pairIndex) -> pairIndex.values }
+            !exchanges.isEmpty() -> index
+                    .flatMap { (_, pairIndex) -> pairIndex.entries }
+                    .filter { (exchange, _) -> exchanges.contains(exchange) }
+                    .map { (_, broadcaster) -> broadcaster }
+            else -> index
+                    .flatMap { (_, pairIndex) -> pairIndex.entries }
+                    .map { (_, broadcaster) -> broadcaster }
+        }
     }
 
-    fun broadcastersForExchanges (exchanges: List<String>): Collection<TokensPairTradesBroadcaster> {
-        return index
-                .flatMap { (_, pairIndex) -> pairIndex.entries }
-                .filter { (exchange, _) -> exchanges.contains(exchange)}
-                .map { (_, broadcaster) -> broadcaster }
-    }
-
-    fun broadcastersForAll (): Collection<TokensPairTradesBroadcaster> {
-        return index
-                .flatMap { (_, pairIndex) -> pairIndex.entries }
-                .map { (_, broadcaster) -> broadcaster }
-    }
-
-    fun broadcastersGetAllPairs (): Collection<TokensPair>{
+    fun getAllPairs (): Collection<TokensPair>{
         return index.keys
     }
 
-    fun broadcastersGetExchangesTree (): MutableMap<String, List<TokensPair>>{
+    fun getAllExchangesWithPairs (): MutableMap<String, List<TokensPair>>{
         var resultMap: HashMap<String, List<TokensPair>> = hashMapOf()
         val indexCopy = index
         val flatMap = indexCopy.flatMap { (_, pairIndex) -> pairIndex.entries }

--- a/stream-api/src/main/kotlin/fund/cyber/markets/api/trades/TradesBroadcastersIndex.kt
+++ b/stream-api/src/main/kotlin/fund/cyber/markets/api/trades/TradesBroadcastersIndex.kt
@@ -12,9 +12,30 @@ class TradesBroadcastersIndex : TradesChannelsIndexUpdateListener {
         index.getOrPut(pair, { HashMap() }).put(exchange, broadcaster)
     }
 
-    fun broadcastersFor(pairs: List<TokensPair>): Collection<TokensPairTradesBroadcaster> {
+    fun broadcastersForPairs (pairs: List<TokensPair>): Collection<TokensPairTradesBroadcaster> {
         return index
                 .filter { (pair, _) -> pairs.contains(pair) }
                 .flatMap { (_, pairIndex) -> pairIndex.values }
+    }
+
+    fun broadcastersFor(pairs: List<TokensPair>, exchanges: List<String> ): Collection<TokensPairTradesBroadcaster> {
+        return index
+                .filter { (pair, _) -> pairs.contains(pair) }
+                .flatMap { (_, pairIndex) -> pairIndex.entries }
+                .filter { (exchange, _) -> exchanges.contains(exchange)}
+                .map { (_, broadcaster) -> broadcaster }
+    }
+
+    fun broadcastersForExchanges (exchanges: List<String>): Collection<TokensPairTradesBroadcaster> {
+        return index
+                .flatMap { (_, pairIndex) -> pairIndex.entries }
+                .filter { (exchange, _) -> exchanges.contains(exchange)}
+                .map { (_, broadcaster) -> broadcaster }
+    }
+
+    fun broadcastersForAll (): Collection<TokensPairTradesBroadcaster> {
+        return index
+                .flatMap { (_, pairIndex) -> pairIndex.entries }
+                .map { (_, broadcaster) -> broadcaster }
     }
 }

--- a/stream-api/src/main/kotlin/fund/cyber/markets/api/trades/TradesBroadcastersIndex.kt
+++ b/stream-api/src/main/kotlin/fund/cyber/markets/api/trades/TradesBroadcastersIndex.kt
@@ -1,6 +1,7 @@
 package fund.cyber.markets.api.trades
 
 import fund.cyber.markets.model.TokensPair
+import java.util.LinkedList
 
 
 class TradesBroadcastersIndex : TradesChannelsIndexUpdateListener {
@@ -37,5 +38,28 @@ class TradesBroadcastersIndex : TradesChannelsIndexUpdateListener {
         return index
                 .flatMap { (_, pairIndex) -> pairIndex.entries }
                 .map { (_, broadcaster) -> broadcaster }
+    }
+
+    fun broadcastersGetAllPairs (): Collection<TokensPair>{
+        return index.keys
+    }
+
+    fun broadcastersGetExchangesTree (): MutableMap<String, List<TokensPair>>{
+        var resultMap: HashMap<String, List<TokensPair>> = hashMapOf()
+        val indexCopy = index
+        val flatMap = indexCopy.flatMap { (_, pairIndex) -> pairIndex.entries }
+        flatMap.forEach { exc ->resultMap.put(exc.key, getAllPairsForExchange(exc.key))}
+        return resultMap
+    }
+
+    private fun getAllPairsForExchange (exchange: String): MutableList<TokensPair> {
+        val indexCopy = index
+        var resultPairsList : LinkedList<TokensPair> = LinkedList()
+        for (el in indexCopy) {
+            if(el.value.keys.contains(exchange)){
+                resultPairsList.add(el.key)
+            }
+        }
+        return resultPairsList
     }
 }

--- a/stream-api/src/main/resources/trades-test.html
+++ b/stream-api/src/main/resources/trades-test.html
@@ -40,6 +40,12 @@
         function send3() {
             websockets.send(`{"subscribe":"trades"}`);
         }
+        function send4() {
+            websockets.send(`{"get":"pairs"}`);
+        }
+        function send5() {
+            websockets.send(`{"get":"exchanges"}`);
+        }
     </script>
 </head>
 <body>
@@ -54,6 +60,12 @@
 </form>
 <form onsubmit="return false;">
     <input type="button" value="Subscribe all" onclick="send3()"/>
+</form>
+<form onsubmit="return false;">
+    <input type="button" value="Get pairs" onclick="send4()"/>
+</form>
+<form onsubmit="return false;">
+    <input type="button" value="Get exchanges with pairs" onclick="send5()"/>
 </form>
 </body>
 </html>

--- a/stream-api/src/main/resources/trades-test.html
+++ b/stream-api/src/main/resources/trades-test.html
@@ -31,11 +31,29 @@
         function send() {
             websockets.send(`{"subscribe":"trades","pairs":["BTC_ETH","ETH_USD"]}`);
         }
+        function send1() {
+            websockets.send(`{"subscribe":"trades","exchanges":["Poloniex","HitBtc"]}`);
+        }
+        function send2() {
+            websockets.send(`{"subscribe":"trades","exchanges":["Poloniex","HitBtc"],"pairs":["BTC_ETH","ETH_USD"]}`);
+        }
+        function send3() {
+            websockets.send(`{"subscribe":"trades"}`);
+        }
     </script>
 </head>
 <body>
 <form onsubmit="return false;">
-    <input type="button" value="Send Web Socket Message" onclick="send()"/>
+    <input type="button" value="Subscribe pairs" onclick="send()"/>
+</form>
+<form onsubmit="return false;">
+    <input type="button" value="Subscribe exchanges" onclick="send1()"/>
+</form>
+<form onsubmit="return false;">
+    <input type="button" value="Subscribe pairs & exchencges" onclick="send2()"/>
+</form>
+<form onsubmit="return false;">
+    <input type="button" value="Subscribe all" onclick="send3()"/>
 </form>
 </body>
 </html>

--- a/stream-api/src/test/kotlin/fund/cyber/markets/exchanges/common/WebSocketCommandsParserTest.kt
+++ b/stream-api/src/test/kotlin/fund/cyber/markets/exchanges/common/WebSocketCommandsParserTest.kt
@@ -40,6 +40,6 @@ class WebSocketCommandsParserTest {
 
         Assertions.assertTrue(command is TradeChannelSubscriptionCommand)
         command as TradeChannelSubscriptionCommand
-        Assertions.assertArrayEquals(pairs.toTypedArray(), command.pairs.toTypedArray())
+        Assertions.assertArrayEquals(pairs.toTypedArray(), command.pairs?.toTypedArray())
     }
 }


### PR DESCRIPTION
implements :
{"subscribe":"trades"} subscribe for all tokens pairs from all supported exchanges
{"subscribe":"trades","pairs":["BTC_ETH","ETH_USD"]} subscribe for given tokens pairs from all supported exchanges
{"subscribe":"trades","exchanges":["Poloniex","HitBtc"]} subscribe for all tokens from given exchanges
{"subscribe":"trades","exchanges":["Poloniex","HitBtc"],"pairs":["BTC_ETH","ETH_USD"]} subscribe for given tokens pairs from all supported exchanges