### PR TITLE
Rewrite CircularQueue to Kotlin.

### DIFF
--- a/core/src/main/java/fund/cyber/markets/common/CircularQueue.kt
+++ b/core/src/main/java/fund/cyber/markets/common/CircularQueue.kt
@@ -1,0 +1,22 @@
+package fund.cyber.markets.common
+
+/**
+ * Queue with limited size, which overrides elements like it a circle.
+ *
+ * @author Ibragimov Ruslan
+ * @since 0.2.4
+ */
+class CircularQueueKotlin<T>(
+    private val maxSize: Int
+) {
+    private val _elements = arrayOfNulls<Any>(maxSize)
+    private var index = 0
+
+    fun addNext(element: T) {
+        _elements[index++] = element
+        if (index == maxSize) index = 0
+    }
+
+    val elements: Array<T?>
+        get() = _elements.clone() as Array<T?>
+}

--- a/core/src/test/kotlin/fund/cyber/markets/common/CircularQueueTest.kt
+++ b/core/src/test/kotlin/fund/cyber/markets/common/CircularQueueTest.kt
@@ -1,0 +1,49 @@
+package fund.cyber.markets.common
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+/**
+ * Test for [CircularQueueKotlin]
+ *
+ * @author Ibragimov Ruslan
+ * @since 0.2.4
+ */
+class CircularQueueTest {
+    @Test
+    fun `max size zero`() {
+        assertThrows(ArrayIndexOutOfBoundsException::class.java, {
+            CircularQueueKotlin<Int>(0).addNext(1)
+        })
+    }
+
+    @Test
+    fun `negative max size`() {
+        assertThrows(NegativeArraySizeException::class.java, {
+            CircularQueueKotlin<Int>(-1).addNext(1)
+        })
+    }
+
+    @Test
+    fun `max size of one`() {
+        val queue = CircularQueueKotlin<Int>(1)
+        queue.addNext(1)
+        assertArrayEquals(arrayOf(1), queue.elements)
+        queue.addNext(2)
+        assertArrayEquals(arrayOf(2), queue.elements)
+        queue.addNext(3)
+        assertArrayEquals(arrayOf(3), queue.elements)
+    }
+
+    @Test
+    fun `max size of two`() {
+        val queue = CircularQueueKotlin<Int>(2)
+        queue.addNext(1)
+        assertArrayEquals(arrayOf(1, null), queue.elements)
+        queue.addNext(2)
+        assertArrayEquals(arrayOf(1, 2), queue.elements)
+        queue.addNext(3)
+        assertArrayEquals(arrayOf(3, 2), queue.elements)
+    }
+}


### PR DESCRIPTION
I create new class and left old one, since that way will be easy to merge with @mgergalov changes, and migrate usages.