### PR TITLE
Feature/cyber-markets-65 unify pairs by alphabet

### DIFF
--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/bitfinex/BitfinexMessageParser.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/bitfinex/BitfinexMessageParser.kt
@@ -52,10 +52,14 @@ class BitfinexTradesMessageParser(
         baseAmount = baseAmount.abs()
 
         val trades = Collections.singletonList(Trade(
-                tradeId = tradeNode[0].asText(), exchange = Exchanges.bitfinex,
-                baseToken = tokensPair.base, quoteToken = tokensPair.quote,
-                type = tradeType, timestamp = tradeNode[1].asLong().div(1000),
-                baseAmount = baseAmount, quoteAmount = rate * baseAmount, spotPrice = rate
+                tradeId = tradeNode[0].asText(),
+                exchange = Exchanges.bitfinex,
+                timestamp = tradeNode[1].asLong().div(1000),
+                type = tradeType,
+                baseAmount = baseAmount,
+                quoteAmount = rate * baseAmount,
+                spotPrice = rate,
+                tokensPair = tokensPair
         ))
 
         return TradesUpdatesMessage(trades)

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/bitfinex/BitfinexMessageParser.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/bitfinex/BitfinexMessageParser.kt
@@ -51,7 +51,7 @@ class BitfinexTradesMessageParser(
         val tradeType = if (baseAmount.signum() > 0) BUY else SELL
         baseAmount = baseAmount.abs()
 
-        val trades = Collections.singletonList(Trade(
+        val trades = Collections.singletonList(Trade.of(
                 tradeId = tradeNode[0].asText(),
                 exchange = Exchanges.bitfinex,
                 timestamp = tradeNode[1].asLong().div(1000),

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/bitstamp/BitstampMessageParser.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/bitstamp/BitstampMessageParser.kt
@@ -28,7 +28,7 @@ class BitstampTradesMessageParser(
         val rate = BigDecimal(tradeNode["price"].asText())
         val baseAmount = BigDecimal(tradeNode["amount"].asText())
         val tradeType = if (tradeNode["type"].asInt() == 0) TradeType.BUY else TradeType.SELL
-        return Trade(
+        return Trade.of(
                 tradeId = tradeNode["id"].asText(),
                 exchange = Exchanges.bitstamp,
                 timestamp = tradeNode["timestamp"].asLong() / 1000,

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/bitstamp/BitstampMessageParser.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/bitstamp/BitstampMessageParser.kt
@@ -29,10 +29,14 @@ class BitstampTradesMessageParser(
         val baseAmount = BigDecimal(tradeNode["amount"].asText())
         val tradeType = if (tradeNode["type"].asInt() == 0) TradeType.BUY else TradeType.SELL
         return Trade(
-                tradeId = tradeNode["id"].asText(), exchange = Exchanges.bitstamp,
-                baseToken = tokensPair.base, quoteToken = tokensPair.quote,
-                type = tradeType, timestamp = tradeNode["timestamp"].asLong() / 1000,
-                baseAmount = baseAmount, quoteAmount = rate * baseAmount, spotPrice = rate
+                tradeId = tradeNode["id"].asText(),
+                exchange = Exchanges.bitstamp,
+                timestamp = tradeNode["timestamp"].asLong() / 1000,
+                type = tradeType,
+                baseAmount = baseAmount,
+                quoteAmount = rate * baseAmount,
+                spotPrice = rate,
+                tokensPair = tokensPair
         )
     }
 }

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcEndpoint.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcEndpoint.kt
@@ -10,7 +10,6 @@ class HitBtcTokensPair(
         val symbol: String,
         val lotSize: BigDecimal,
         val priceStep: BigDecimal,
-        reverted: Boolean,
         base: String,
         quote: String
 ) : TokensPair(base, quote)

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcEndpoint.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcEndpoint.kt
@@ -10,7 +10,7 @@ class HitBtcTokensPair(
         val symbol: String,
         val lotSize: BigDecimal,
         val priceStep: BigDecimal,
-        var reverted: Boolean,
+        reverted: Boolean,
         base: String,
         quote: String
 ) : TokensPair(base, quote)

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcEndpoint.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcEndpoint.kt
@@ -10,6 +10,7 @@ class HitBtcTokensPair(
         val symbol: String,
         val lotSize: BigDecimal,
         val priceStep: BigDecimal,
+        var reverted: Boolean,
         base: String,
         quote: String
 ) : TokensPair(base, quote)

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcMessageParser.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcMessageParser.kt
@@ -35,7 +35,7 @@ class HitBtcTradesMessageParser(
                     val spotPrice = BigDecimal(tradeNode["price"].asText())
                     val type = TradeType.valueOf(tradeNode["side"].asText().toUpperCase())
                     val quoteAmount = spotPrice * baseAmount
-                    Trade(
+                    Trade.of(
                             tradeId = tradeNode["tradeId"].asText(),
                             exchange = Exchanges.hitbtc,
                             timestamp = timestamp,

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcMessageParser.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcMessageParser.kt
@@ -49,14 +49,6 @@ class HitBtcTradesMessageParser(
         return TradesUpdatesMessage(trades)
     }
 
-    private fun findType(type: TradeType) : TradeType {
-        return when (type){
-            TradeType.BUY -> TradeType.SELL
-            TradeType.SELL -> TradeType.BUY
-            else -> type
-        }
-    }
-
 }
 
 class HitBtcOrdersMessageParser(

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcMessageParser.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcMessageParser.kt
@@ -31,26 +31,19 @@ class HitBtcTradesMessageParser(
 
         val trades = node["trade"].toList()
                 .map { tradeNode ->
-                    var baseAmount = BigDecimal(tradeNode["size"].asText()).multiply(tokensPair.lotSize)
-                    var spotPrice = BigDecimal(tradeNode["price"].asText())
-                    var type = TradeType.valueOf(tradeNode["side"].asText().toUpperCase())
-                    var quoteAmount = spotPrice * baseAmount
-
-                    if(tokensPair.reverted){
-                        var temporaryAmount = quoteAmount
-                        quoteAmount = baseAmount
-                        baseAmount = temporaryAmount
-                        spotPrice = quoteAmount / baseAmount
-                        type = findType(type)
-                    }
+                    val baseAmount = BigDecimal(tradeNode["size"].asText()).multiply(tokensPair.lotSize)
+                    val spotPrice = BigDecimal(tradeNode["price"].asText())
+                    val type = TradeType.valueOf(tradeNode["side"].asText().toUpperCase())
+                    val quoteAmount = spotPrice * baseAmount
                     Trade(
-                            tradeId = tradeNode["tradeId"].asText(), exchange = Exchanges.hitbtc,
-                            baseToken = tokensPair.base, quoteToken = tokensPair.quote,
+                            tradeId = tradeNode["tradeId"].asText(),
+                            exchange = Exchanges.hitbtc,
+                            timestamp = timestamp,
                             type = type,
                             baseAmount = baseAmount,
                             quoteAmount = quoteAmount,
                             spotPrice = spotPrice,
-                            timestamp = timestamp
+                            tokensPair = tokensPair
                     )
                 }
         return TradesUpdatesMessage(trades)

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcPairsProvider.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcPairsProvider.kt
@@ -24,16 +24,16 @@ class HitBtcPairsProvider: PairsProvider {
     }
 
     private fun hitBtcTokensPair(symbolInfo: JsonNode): HitBtcTokensPair {
-        var jsonBase = symbolInfo["commodity"].asText()
-        var jsonQuote = symbolInfo["currency"].asText()
-        var tokensPair = TokensPair(jsonBase, jsonQuote)
-        var result = HitBtcTokensPair(
+        val jsonBase = symbolInfo["commodity"].asText()
+        val jsonQuote = symbolInfo["currency"].asText()
+        val tokensPair = TokensPair(jsonBase, jsonQuote)
+        val result = HitBtcTokensPair(
                 base = tokensPair.base,
                 quote = tokensPair.quote,
                 symbol = symbolInfo["symbol"].asText(),
                 lotSize = BigDecimal(symbolInfo["lot"].asText()),
                 priceStep = BigDecimal(symbolInfo["step"].asText()),
-                reverted = jsonBase != tokensPair.base
+                reverted = tokensPair.reverted
         )
         return result
     }

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcPairsProvider.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcPairsProvider.kt
@@ -24,12 +24,17 @@ class HitBtcPairsProvider: PairsProvider {
     }
 
     private fun hitBtcTokensPair(symbolInfo: JsonNode): HitBtcTokensPair {
-        val tokensPair = HitBtcTokensPair(
-                base = symbolInfo["commodity"].asText(), quote = symbolInfo["currency"].asText(),
+        var jsonBase = symbolInfo["commodity"].asText()
+        var jsonQuote = symbolInfo["currency"].asText()
+        var tokensPair = TokensPair(jsonBase, jsonQuote)
+        var result = HitBtcTokensPair(
+                base = tokensPair.base,
+                quote = tokensPair.quote,
                 symbol = symbolInfo["symbol"].asText(),
                 lotSize = BigDecimal(symbolInfo["lot"].asText()),
-                priceStep = BigDecimal(symbolInfo["step"].asText())
+                priceStep = BigDecimal(symbolInfo["step"].asText()),
+                reverted = jsonBase != tokensPair.base
         )
-        return tokensPair
+        return result
     }
 }

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcPairsProvider.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/hitbtc/HitBtcPairsProvider.kt
@@ -24,16 +24,12 @@ class HitBtcPairsProvider: PairsProvider {
     }
 
     private fun hitBtcTokensPair(symbolInfo: JsonNode): HitBtcTokensPair {
-        val jsonBase = symbolInfo["commodity"].asText()
-        val jsonQuote = symbolInfo["currency"].asText()
-        val tokensPair = TokensPair(jsonBase, jsonQuote)
         val result = HitBtcTokensPair(
-                base = tokensPair.base,
-                quote = tokensPair.quote,
+                base = symbolInfo["commodity"].asText(),
+                quote = symbolInfo["currency"].asText(),
                 symbol = symbolInfo["symbol"].asText(),
                 lotSize = BigDecimal(symbolInfo["lot"].asText()),
-                priceStep = BigDecimal(symbolInfo["step"].asText()),
-                reverted = tokensPair.reverted
+                priceStep = BigDecimal(symbolInfo["step"].asText())
         )
         return result
     }

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/poloniex/PoloniexMessageParser.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/poloniex/PoloniexMessageParser.kt
@@ -43,7 +43,7 @@ class PoloniexTradesMessageParser(
         val baseAmount = BigDecimal(node[4].asText())
         val quoteAmount = spotPrice * baseAmount
         val type = if (node[2].asInt() == 0) SELL else BUY
-        return Trade (
+        return Trade.of(
                 tradeId = node[1].asText(),
                 exchange = Exchanges.poloniex,
                 timestamp = node[5].asLong(),

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/poloniex/PoloniexMessageParser.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/poloniex/PoloniexMessageParser.kt
@@ -41,12 +41,17 @@ class PoloniexTradesMessageParser(
     private fun parseTrade(node: JsonNode, tokensPair: TokensPair): Trade {
         val spotPrice = BigDecimal(node[3].asText())
         val baseAmount = BigDecimal(node[4].asText())
+        val quoteAmount = spotPrice * baseAmount
+        val type = if (node[2].asInt() == 0) SELL else BUY
         return Trade (
-                tradeId = node[1].asText(), exchange = Exchanges.poloniex,
-                baseToken = tokensPair.base, quoteToken = tokensPair.quote,
-                type = if (node[2].asInt() == 0) SELL else BUY,
-                baseAmount = baseAmount, quoteAmount = spotPrice * baseAmount,
-                spotPrice = spotPrice, timestamp = node[5].asLong()
+                tradeId = node[1].asText(),
+                exchange = Exchanges.poloniex,
+                timestamp = node[5].asLong(),
+                type = type,
+                baseAmount = baseAmount,
+                quoteAmount = quoteAmount,
+                spotPrice = spotPrice,
+                tokensPair = tokensPair
         )
     }
 }

--- a/connectors/src/main/kotlin/fund/cyber/markets/connectors/poloniex/PoloniexPairsProvider.kt
+++ b/connectors/src/main/kotlin/fund/cyber/markets/connectors/poloniex/PoloniexPairsProvider.kt
@@ -8,7 +8,7 @@ import fund.cyber.markets.model.TokensPair
 import okhttp3.Request
 
 
-class PoloniexPairsProvider: PairsProvider {
+class PoloniexPairsProvider : PairsProvider {
 
     private val tickerRequest = Request.Builder().url("https://poloniex.com/public?command=returnTicker").build()!!
 
@@ -19,7 +19,8 @@ class PoloniexPairsProvider: PairsProvider {
         val pairsTickers = jsonParser.readTree(response.body()?.string())
 
         pairsTickers.fields().forEach { pairTicker ->
-            result.put(pairTicker.value["id"].asText(), TokensPair.fromLabel(pairTicker.key, "_"))
+            val tokensPair = TokensPair.fromLabel(pairTicker.key, "_")
+            result.put(pairTicker.value["id"].asText(), TokensPair(tokensPair.base, tokensPair.quote))
         }
 
         return result

--- a/connectors/src/test/kotlin/fund/cyber/markets/exchanges/bitfinex/BitfinexMessageParserTest.kt
+++ b/connectors/src/test/kotlin/fund/cyber/markets/exchanges/bitfinex/BitfinexMessageParserTest.kt
@@ -31,10 +31,14 @@ class BitfinexMessageParserTest {
         assertTrue((exchangeMessage as TradesUpdatesMessage).trades.size == 1)
 
         val trade = Trade(
-                tradeId = "43334639", exchange = "Bitfinex", type = SELL,
-                baseToken = tokensPair.base, quoteToken = tokensPair.quote,
-                baseAmount = BigDecimal("0.01293103"), quoteAmount = BigDecimal("0.01293103") * BigDecimal("2320"),
-                spotPrice = BigDecimal("2320"), timestamp = 1499972199
+                tradeId = "43334639",
+                exchange = "Bitfinex",
+                timestamp = 1499972199,
+                type = SELL,
+                baseAmount = BigDecimal("0.01293103"),
+                quoteAmount = BigDecimal("0.01293103") * BigDecimal("2320"),
+                spotPrice = BigDecimal("2320"),
+                tokensPair = tokensPair
         )
         assertEquals(trade, exchangeMessage.trades[0])
     }

--- a/connectors/src/test/kotlin/fund/cyber/markets/exchanges/bitfinex/BitfinexMessageParserTest.kt
+++ b/connectors/src/test/kotlin/fund/cyber/markets/exchanges/bitfinex/BitfinexMessageParserTest.kt
@@ -30,7 +30,7 @@ class BitfinexMessageParserTest {
         assertTrue(exchangeMessage is TradesUpdatesMessage)
         assertTrue((exchangeMessage as TradesUpdatesMessage).trades.size == 1)
 
-        val trade = Trade(
+        val trade = Trade.of(
                 tradeId = "43334639",
                 exchange = "Bitfinex",
                 timestamp = 1499972199,

--- a/connectors/src/test/kotlin/fund/cyber/markets/exchanges/common/TokensPairTest.kt
+++ b/connectors/src/test/kotlin/fund/cyber/markets/exchanges/common/TokensPairTest.kt
@@ -24,5 +24,37 @@ class TokensPairTest {
         Assertions.assertEquals(comparedAttempt.base, incomparableAttempt.base)
         Assertions.assertEquals(comparedAttempt.quote, incomparableAttempt.quote)
     }
+
+    @Test
+    @DisplayName("base and quote was compare by dictionary")
+    fun testInitTokenPairWithCompareBaseAndQuoteByDictionary() {
+        val base = "BTC"
+        val quote = "USDT"
+        val correctTokenPair = TokensPair(base,quote)
+        val incorrectTokenPair = TokensPair(quote, base)
+
+        //will be BTC_USDT pair
+        Assertions.assertEquals(correctTokenPair.base, incorrectTokenPair.base)
+        Assertions.assertEquals(correctTokenPair.quote, incorrectTokenPair.quote)
+        Assertions.assertEquals(correctTokenPair.base, base)
+        Assertions.assertEquals(correctTokenPair.quote, quote)
+    }
+
+    @Test
+    @DisplayName("Token pair reverted if needed")
+    fun testTokenPairReverted() {
+        val base = "BTC"
+        val quote = "USDT"
+        val nonRevertedTokenPair = TokensPair(base,quote)
+        val revertedTokenPair = TokensPair(quote, base)
+
+        //will be BTC_USDT pair
+        Assertions.assertEquals(nonRevertedTokenPair.base, revertedTokenPair.base)
+        Assertions.assertEquals(nonRevertedTokenPair.quote, revertedTokenPair.quote)
+        Assertions.assertEquals(nonRevertedTokenPair.base, base)
+        Assertions.assertEquals(nonRevertedTokenPair.quote, quote)
+        Assertions.assertTrue(revertedTokenPair.reverted)
+        Assertions.assertFalse(nonRevertedTokenPair.reverted)
+    }
     
 }

--- a/connectors/src/test/kotlin/fund/cyber/markets/exchanges/common/TokensPairTest.kt
+++ b/connectors/src/test/kotlin/fund/cyber/markets/exchanges/common/TokensPairTest.kt
@@ -1,0 +1,28 @@
+package fund.cyber.markets.exchanges.common
+
+import fund.cyber.markets.model.TokensPair
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * @author mgergalov
+ */
+@DisplayName("Every time when token pair created:")
+class TokensPairTest {
+
+    @Test
+    @DisplayName("base and quote was compare alphabetically")
+    fun testInitTokenPairWithCompareBaseAndQuote() {
+        val firstInAlphabet = "aaa"
+        val secondInAlphabet = "bbb"
+        val comparedAttempt = TokensPair(firstInAlphabet,secondInAlphabet)
+        val incomparableAttempt = TokensPair(secondInAlphabet, firstInAlphabet)
+
+        Assertions.assertTrue(firstInAlphabet.compareTo(secondInAlphabet, true) < 0)
+        Assertions.assertTrue(comparedAttempt.base.compareTo(comparedAttempt.quote, true) < 0)
+        Assertions.assertEquals(comparedAttempt.base, incomparableAttempt.base)
+        Assertions.assertEquals(comparedAttempt.quote, incomparableAttempt.quote)
+    }
+    
+}

--- a/connectors/src/test/kotlin/fund/cyber/markets/exchanges/hitbtc/HitBtcMessageParserTest.kt
+++ b/connectors/src/test/kotlin/fund/cyber/markets/exchanges/hitbtc/HitBtcMessageParserTest.kt
@@ -62,7 +62,7 @@ class HitBtcMessageParserTest {
         Assertions.assertTrue(exchangeMessage is TradesUpdatesMessage)
         Assertions.assertTrue((exchangeMessage as TradesUpdatesMessage).trades.size == 2)
 
-        val firstTrade = Trade(
+        val firstTrade = Trade.of(
                 tradeId = "12987994",
                 exchange = "HitBtc",
                 timestamp = 1500048731,
@@ -72,7 +72,7 @@ class HitBtcMessageParserTest {
                 spotPrice = BigDecimal("0.00020699"),
                 tokensPair = tokensPair
         )
-        val secondTrade = Trade(
+        val secondTrade = Trade.of(
                 tradeId = "12987997",
                 exchange = "HitBtc",
                 timestamp = 1500048731,

--- a/connectors/src/test/kotlin/fund/cyber/markets/exchanges/hitbtc/HitBtcMessageParserTest.kt
+++ b/connectors/src/test/kotlin/fund/cyber/markets/exchanges/hitbtc/HitBtcMessageParserTest.kt
@@ -47,8 +47,12 @@ class HitBtcMessageParserTest {
     fun testParseOkTrade() {
 
         val tokensPair = HitBtcTokensPair(
-                base = "LTC", quote = "BTC", symbol = "LTCBTC",
-                lotSize = BigDecimal("0.1"), priceStep = BigDecimal("0.00001")
+                base = "LTC",
+                quote = "BTC",
+                symbol = "LTCBTC",
+                lotSize = BigDecimal("0.1"),
+                priceStep = BigDecimal("0.00001"),
+                reverted = false
         )
 
         val channelSymbolForTokensPair = mapOf(Pair(tokensPair.symbol, tokensPair))
@@ -59,16 +63,24 @@ class HitBtcMessageParserTest {
         Assertions.assertTrue((exchangeMessage as TradesUpdatesMessage).trades.size == 2)
 
         val firstTrade = Trade(
-                tradeId = "12987994", exchange = "HitBtc", type = BUY,
-                baseToken = tokensPair.base, quoteToken = tokensPair.quote,
-                baseAmount = BigDecimal("1.2"), quoteAmount = BigDecimal("0.000248388"),
-                spotPrice = BigDecimal("0.00020699"), timestamp = 1500048731
+                tradeId = "12987994",
+                exchange = "HitBtc",
+                timestamp = 1500048731,
+                type = BUY,
+                baseAmount = BigDecimal("1.2"),
+                quoteAmount = BigDecimal("0.000248388"),
+                spotPrice = BigDecimal("0.00020699"),
+                tokensPair = tokensPair
         )
         val secondTrade = Trade(
-                tradeId = "12987997", exchange = "HitBtc", type = SELL,
-                baseToken = tokensPair.base, quoteToken = tokensPair.quote,
-                baseAmount = BigDecimal("0.2"), quoteAmount = BigDecimal("0.000267398"),
-                spotPrice = BigDecimal("0.00133699"), timestamp = 1500048731
+                tradeId = "12987997",
+                exchange = "HitBtc",
+                timestamp = 1500048731,
+                type = SELL,
+                baseAmount = BigDecimal("0.2"),
+                quoteAmount = BigDecimal("0.000267398"),
+                spotPrice = BigDecimal("0.00133699"),
+                tokensPair = tokensPair
         )
         Assertions.assertEquals(firstTrade, exchangeMessage.trades[0])
         Assertions.assertEquals(secondTrade, exchangeMessage.trades[1])

--- a/connectors/src/test/kotlin/fund/cyber/markets/exchanges/hitbtc/HitBtcMessageParserTest.kt
+++ b/connectors/src/test/kotlin/fund/cyber/markets/exchanges/hitbtc/HitBtcMessageParserTest.kt
@@ -51,8 +51,7 @@ class HitBtcMessageParserTest {
                 quote = "BTC",
                 symbol = "LTCBTC",
                 lotSize = BigDecimal("0.1"),
-                priceStep = BigDecimal("0.00001"),
-                reverted = false
+                priceStep = BigDecimal("0.00001")
         )
 
         val channelSymbolForTokensPair = mapOf(Pair(tokensPair.symbol, tokensPair))

--- a/connectors/src/test/kotlin/fund/cyber/markets/exchanges/poloniex/PoloniexMessageParserTest.kt
+++ b/connectors/src/test/kotlin/fund/cyber/markets/exchanges/poloniex/PoloniexMessageParserTest.kt
@@ -36,7 +36,7 @@ class PoloniexMessageParserTest {
         Assertions.assertTrue(exchangeMessage is TradesUpdatesMessage)
         Assertions.assertTrue((exchangeMessage as TradesUpdatesMessage).trades.size == 2)
 
-        val firstTrade = Trade(
+        val firstTrade = Trade.of(
                 tradeId = "126320",
                 exchange = "Poloniex",
                 timestamp = 1499708547,
@@ -46,7 +46,7 @@ class PoloniexMessageParserTest {
                 spotPrice = BigDecimal("0.00003328"),
                 tokensPair = tokensPair
         )
-        val secondTrade = Trade(
+        val secondTrade = Trade.of(
                 tradeId = "126321",
                 exchange = "Poloniex",
                 timestamp = 1499708549,

--- a/connectors/src/test/kotlin/fund/cyber/markets/exchanges/poloniex/PoloniexMessageParserTest.kt
+++ b/connectors/src/test/kotlin/fund/cyber/markets/exchanges/poloniex/PoloniexMessageParserTest.kt
@@ -37,16 +37,24 @@ class PoloniexMessageParserTest {
         Assertions.assertTrue((exchangeMessage as TradesUpdatesMessage).trades.size == 2)
 
         val firstTrade = Trade(
-                tradeId = "126320", exchange = "Poloniex", type = TradeType.BUY,
-                baseToken = tokensPair.base, quoteToken = tokensPair.quote,
-                baseAmount = BigDecimal("399377.76875000"), quoteAmount = BigDecimal("13.2912921440000000"),
-                spotPrice = BigDecimal("0.00003328"), timestamp = 1499708547
+                tradeId = "126320",
+                exchange = "Poloniex",
+                timestamp = 1499708547,
+                type = TradeType.BUY,
+                baseAmount = BigDecimal("399377.76875000"),
+                quoteAmount = BigDecimal("13.2912921440000000"),
+                spotPrice = BigDecimal("0.00003328"),
+                tokensPair = tokensPair
         )
         val secondTrade = Trade(
-                tradeId = "126321", exchange = "Poloniex", type = TradeType.SELL,
-                baseToken = tokensPair.base, quoteToken = tokensPair.quote,
-                baseAmount = BigDecimal("2.76875000"), quoteAmount = BigDecimal("0.0006458940000000"),
-                spotPrice = BigDecimal("0.00023328"), timestamp = 1499708549
+                tradeId = "126321",
+                exchange = "Poloniex",
+                timestamp = 1499708549,
+                type = TradeType.SELL,
+                baseAmount = BigDecimal("2.76875000"),
+                quoteAmount = BigDecimal("0.0006458940000000"),
+                spotPrice = BigDecimal("0.00023328"),
+                tokensPair = tokensPair
         )
         Assertions.assertEquals(firstTrade, exchangeMessage.trades[0])
         Assertions.assertEquals(secondTrade, exchangeMessage.trades[1])

--- a/core/src/main/kotlin/fund/cyber/markets/model/ExchangeModel.kt
+++ b/core/src/main/kotlin/fund/cyber/markets/model/ExchangeModel.kt
@@ -16,20 +16,6 @@ enum class OrderType {
     UNKNOWN
 }
 
-data class Trade (
-
-        //some markets get crazy id (ex: kraken - 1499515072.2199)
-        val tradeId: String,
-        val exchange: String,
-        val timestamp: Long,
-        val type: TradeType,
-        val baseToken: String,
-        val quoteToken: String,
-        val baseAmount: BigDecimal,
-        val quoteAmount: BigDecimal,
-        val spotPrice: BigDecimal
-)
-
 data class Order (
         val type: OrderType,
         val exchange: String,

--- a/core/src/main/kotlin/fund/cyber/markets/model/TokensPair.kt
+++ b/core/src/main/kotlin/fund/cyber/markets/model/TokensPair.kt
@@ -4,6 +4,7 @@ open class TokensPair(firstCurrency: String, secondCurrency: String) {
 
     val base: String
     val quote: String
+    var reverted: Boolean = false
     var fiatDictionary = listOf(
             "USD", "EUR", "GBP"
     )
@@ -26,6 +27,7 @@ open class TokensPair(firstCurrency: String, secondCurrency: String) {
             if (firstImportance < secondImportance) {
                 this.base = secondCurrency
                 this.quote = firstCurrency
+                this.reverted =  true
             } else {
                 this.base = firstCurrency
                 this.quote = secondCurrency
@@ -34,6 +36,7 @@ open class TokensPair(firstCurrency: String, secondCurrency: String) {
             if (firstImportance >= 0) {
                 this.base = secondCurrency
                 this.quote = firstCurrency
+                this.reverted =  true
             } else {
                 this.base = firstCurrency
                 this.quote = secondCurrency
@@ -45,6 +48,7 @@ open class TokensPair(firstCurrency: String, secondCurrency: String) {
             } else {
                 this.base = secondCurrency
                 this.quote = firstCurrency
+                this.reverted =  true
             }
         }
     }

--- a/core/src/main/kotlin/fund/cyber/markets/model/TokensPair.kt
+++ b/core/src/main/kotlin/fund/cyber/markets/model/TokensPair.kt
@@ -4,26 +4,39 @@ open class TokensPair(firstCurrency: String, secondCurrency: String) {
 
     val base: String
     val quote: String
-    var dictionary = listOf("BTC", "ETH", "XMR", "USD")
+    var fiatDictionary = listOf(
+            "USD", "EUR", "GBP"
+    )
+    var backedCryptoDictionary = listOf(
+            "USDT"
+    )
+    var cryptoDictionary = listOf(
+            "BTC", "ETH", "XMR"
+    )
 
     init {
-        val firstImportance = dictionary.indexOf(firstCurrency)
-        val secondImportance = dictionary.indexOf(secondCurrency)
+        val fullDictionary = ArrayList(fiatDictionary)
+        fullDictionary.addAll(backedCryptoDictionary)
+        fullDictionary.addAll(cryptoDictionary)
+
+        val firstImportance = fullDictionary.indexOf(firstCurrency)
+        val secondImportance = fullDictionary.indexOf(secondCurrency)
+
         if (firstImportance >= 0 && secondImportance >= 0) {
             if (firstImportance < secondImportance) {
-                this.base = firstCurrency
-                this.quote = secondCurrency
-            } else {
                 this.base = secondCurrency
                 this.quote = firstCurrency
+            } else {
+                this.base = firstCurrency
+                this.quote = secondCurrency
             }
         } else if (firstImportance >= 0 || secondImportance >= 0) {
             if (firstImportance >= 0) {
-                this.base = firstCurrency
-                this.quote = secondCurrency
-            } else {
                 this.base = secondCurrency
                 this.quote = firstCurrency
+            } else {
+                this.base = firstCurrency
+                this.quote = secondCurrency
             }
         } else {
             if (firstCurrency.compareTo(secondCurrency, true) < 0) {

--- a/core/src/main/kotlin/fund/cyber/markets/model/TokensPair.kt
+++ b/core/src/main/kotlin/fund/cyber/markets/model/TokensPair.kt
@@ -1,9 +1,20 @@
 package fund.cyber.markets.model
 
-open class TokensPair(
-        val base: String,
-        val quote: String
-) {
+open class TokensPair(firstCurrency: String, secondCurrency: String) {
+
+    val base: String
+    val quote: String
+
+    init {
+        if(firstCurrency.compareTo(secondCurrency,true) < 0) {
+            this.base = firstCurrency
+            this.quote = secondCurrency
+        } else {
+            this.base = secondCurrency
+            this.quote = firstCurrency
+        }
+    }
+
     fun label(delimiter: String = "/"): String {
         return base + delimiter + quote
     }
@@ -31,4 +42,5 @@ open class TokensPair(
             return TokensPair(label.substringBefore(delimiter), label.substringAfter(delimiter))
         }
     }
+
 }

--- a/core/src/main/kotlin/fund/cyber/markets/model/TokensPair.kt
+++ b/core/src/main/kotlin/fund/cyber/markets/model/TokensPair.kt
@@ -4,14 +4,35 @@ open class TokensPair(firstCurrency: String, secondCurrency: String) {
 
     val base: String
     val quote: String
+    var dictionary = listOf("BTC", "ETH", "XMR", "USD")
 
     init {
-        if(firstCurrency.compareTo(secondCurrency,true) < 0) {
-            this.base = firstCurrency
-            this.quote = secondCurrency
+        val firstImportance = dictionary.indexOf(firstCurrency)
+        val secondImportance = dictionary.indexOf(secondCurrency)
+        if (firstImportance >= 0 && secondImportance >= 0) {
+            if (firstImportance < secondImportance) {
+                this.base = firstCurrency
+                this.quote = secondCurrency
+            } else {
+                this.base = secondCurrency
+                this.quote = firstCurrency
+            }
+        } else if (firstImportance >= 0 || secondImportance >= 0) {
+            if (firstImportance >= 0) {
+                this.base = firstCurrency
+                this.quote = secondCurrency
+            } else {
+                this.base = secondCurrency
+                this.quote = firstCurrency
+            }
         } else {
-            this.base = secondCurrency
-            this.quote = firstCurrency
+            if (firstCurrency.compareTo(secondCurrency, true) < 0) {
+                this.base = firstCurrency
+                this.quote = secondCurrency
+            } else {
+                this.base = secondCurrency
+                this.quote = firstCurrency
+            }
         }
     }
 

--- a/core/src/main/kotlin/fund/cyber/markets/model/Trade.kt
+++ b/core/src/main/kotlin/fund/cyber/markets/model/Trade.kt
@@ -1,0 +1,48 @@
+package fund.cyber.markets.model
+
+import java.math.BigDecimal
+
+/**
+ * @author mgergalov
+ */
+open class Trade(
+        val tradeId: String,
+        val exchange: String,
+        val timestamp: Long,
+        type: TradeType,
+        baseAmount: BigDecimal,
+        quoteAmount: BigDecimal,
+        spotPrice: BigDecimal,
+        tokensPair: TokensPair
+){
+
+    val baseToken : String = tokensPair.base
+    val quoteToken : String = tokensPair.quote
+    val type : TradeType
+    val baseAmount : BigDecimal
+    val quoteAmount : BigDecimal
+    val spotPrice : BigDecimal
+    val reverted : Boolean = tokensPair.reverted
+
+    init {
+        if(tokensPair.reverted) {
+            this.type = revertType(type)
+            this.baseAmount = quoteAmount
+            this.quoteAmount = baseAmount
+            this.spotPrice = this.quoteAmount / this.baseAmount
+        } else {
+            this.type = type
+            this.baseAmount = baseAmount
+            this.quoteAmount = quoteAmount
+            this.spotPrice = spotPrice
+        }
+    }
+
+    private fun revertType(type: TradeType) : TradeType {
+        return when (type){
+            TradeType.BUY -> TradeType.SELL
+            TradeType.SELL -> TradeType.BUY
+            else -> type
+        }
+    }
+}

--- a/core/src/main/kotlin/fund/cyber/markets/model/Trade.kt
+++ b/core/src/main/kotlin/fund/cyber/markets/model/Trade.kt
@@ -45,4 +45,9 @@ open class Trade(
             else -> type
         }
     }
+
+    override fun toString(): String {
+        return "Trade(tradeId='$tradeId', exchange='$exchange', timestamp=$timestamp, baseToken='$baseToken', quoteToken='$quoteToken', type=$type, baseAmount=$baseAmount, quoteAmount=$quoteAmount, spotPrice=$spotPrice, reverted=$reverted)"
+    }
+
 }

--- a/core/src/main/kotlin/fund/cyber/markets/model/Trade.kt
+++ b/core/src/main/kotlin/fund/cyber/markets/model/Trade.kt
@@ -5,49 +5,55 @@ import java.math.BigDecimal
 /**
  * @author mgergalov
  */
-open class Trade(
+data class Trade(
         val tradeId: String,
         val exchange: String,
         val timestamp: Long,
-        type: TradeType,
-        baseAmount: BigDecimal,
-        quoteAmount: BigDecimal,
-        spotPrice: BigDecimal,
-        tokensPair: TokensPair
-){
+        val type: TradeType,
+        val baseToken: String,
+        val quoteToken: String,
+        val baseAmount: BigDecimal,
+        val quoteAmount: BigDecimal,
+        val spotPrice: BigDecimal,
+        val reverted: Boolean
+) {
 
-    val baseToken : String = tokensPair.base
-    val quoteToken : String = tokensPair.quote
-    val type : TradeType
-    val baseAmount : BigDecimal
-    val quoteAmount : BigDecimal
-    val spotPrice : BigDecimal
-    val reverted : Boolean = tokensPair.reverted
-
-    init {
-        if(tokensPair.reverted) {
-            this.type = revertType(type)
-            this.baseAmount = quoteAmount
-            this.quoteAmount = baseAmount
-            this.spotPrice = this.quoteAmount / this.baseAmount
-        } else {
-            this.type = type
-            this.baseAmount = baseAmount
-            this.quoteAmount = quoteAmount
-            this.spotPrice = spotPrice
+    companion object {
+        fun of(tradeId: String,
+               exchange: String,
+               timestamp: Long,
+               type: TradeType,
+               baseAmount: BigDecimal,
+               quoteAmount: BigDecimal,
+               spotPrice: BigDecimal,
+               tokensPair: TokensPair
+        ): Trade {
+            val resType: TradeType
+            val resBaseAmount: BigDecimal
+            val resQuoteAmount: BigDecimal
+            val resSpotPrice: BigDecimal
+            if (tokensPair.reverted) {
+                resType = revertType(type)
+                resBaseAmount = quoteAmount
+                resQuoteAmount = baseAmount
+                resSpotPrice = quoteAmount / baseAmount
+            } else {
+                resType = type
+                resBaseAmount = baseAmount
+                resQuoteAmount = quoteAmount
+                resSpotPrice = spotPrice
+            }
+            return Trade(tradeId, exchange, timestamp, type, tokensPair.base, tokensPair.quote, resBaseAmount,
+                    resQuoteAmount, resSpotPrice, tokensPair.reverted)
         }
-    }
 
-    private fun revertType(type: TradeType) : TradeType {
-        return when (type){
-            TradeType.BUY -> TradeType.SELL
-            TradeType.SELL -> TradeType.BUY
-            else -> type
+        private fun revertType(type: TradeType): TradeType {
+            return when (type) {
+                TradeType.BUY -> TradeType.SELL
+                TradeType.SELL -> TradeType.BUY
+                else -> type
+            }
         }
-    }
-
-    override fun toString(): String {
-        return "Trade(tradeId='$tradeId', exchange='$exchange', timestamp=$timestamp, baseToken='$baseToken', quoteToken='$quoteToken', type=$type, baseAmount=$baseAmount, quoteAmount=$quoteAmount, spotPrice=$spotPrice, reverted=$reverted)"
     }
 
 }

--- a/stream-api/src/main/kotlin/fund/cyber/markets/api/common/WebSocketCommandsParser.kt
+++ b/stream-api/src/main/kotlin/fund/cyber/markets/api/common/WebSocketCommandsParser.kt
@@ -67,6 +67,7 @@ class WebSocketCommandsParser(
     }
 
     private fun parsePairs(jsonMessage: JsonNode): List<TokensPair> {
-        return jsonMessage["pairs"]?.map { pairLabel -> TokensPair.fromLabel(pairLabel.asText(), "_") } ?: emptyList()
+        return jsonMessage["pairs"]?.map {
+            pairLabel -> TokensPair.fromLabel(pairLabel.asText(), "_") }?.distinct() ?: emptyList()
     }
 }

--- a/stream-api/src/test/kotlin/fund/cyber/markets/exchanges/common/WebSocketCommandsParserTest.kt
+++ b/stream-api/src/test/kotlin/fund/cyber/markets/exchanges/common/WebSocketCommandsParserTest.kt
@@ -44,4 +44,39 @@ class WebSocketCommandsParserTest {
         Assertions.assertEquals(IncomingMessageSubscribeTopicType.TRADES, command.type)
         Assertions.assertArrayEquals(pairs.toTypedArray(), command.pairs?.toTypedArray())
     }
+
+    @Test
+    @DisplayName("Should parse trades subscription and invert pair by alphabet if needed")
+    fun testTradeSubscriptionProvidedAndInvertIsCorrect() {
+
+        val pairs = listOf(
+                TokensPair.fromLabel("BTC_ETH", "_"),
+                TokensPair.fromLabel("AAA_BBB", "_")
+        )
+
+        val message = """{"subscribe":"trades","pairs":["BTC_ETH","BBB_AAA"]}"""
+        val command = commandsParser.parseMessage(message)
+
+        Assertions.assertTrue(command is ChannelSubscriptionCommand)
+        command as ChannelSubscriptionCommand
+        Assertions.assertEquals(IncomingMessageSubscribeTopicType.TRADES, command.type)
+        Assertions.assertArrayEquals(pairs.toTypedArray(), command.pairs?.toTypedArray())
+    }
+
+    @Test
+    @DisplayName("Should parse trades subscription, invert pair by alphabet and delete equals")
+    fun testTradeSubscriptionProvidedInvertIsCorrectAndDeleteEquals() {
+
+        val pairs = listOf(
+                TokensPair.fromLabel("BTC_ETH", "_")
+        )
+
+        val message = """{"subscribe":"trades","pairs":["BTC_ETH","ETH_BTC"]}"""
+        val command = commandsParser.parseMessage(message)
+
+        Assertions.assertTrue(command is ChannelSubscriptionCommand)
+        command as ChannelSubscriptionCommand
+        Assertions.assertEquals(IncomingMessageSubscribeTopicType.TRADES, command.type)
+        Assertions.assertArrayEquals(pairs.toTypedArray(), command.pairs?.toTypedArray())
+    }
 }


### PR DESCRIPTION
- change Pair object init;
- change fix stream-api subscription flow;
- add tests;
- revert token pairs and trades for HitBtc;
- add dictionaries structure;
- Bitfinex token pairs unify support impl;
- HitBtc token unify support impl;
- Poloniex token unify support impl;
- Bitstamp token unify support impl;
- Trade constructor to unify view impl;
- Tests fix;
- Poloniex fix incorrect message parse;